### PR TITLE
Customize each project's docs link

### DIFF
--- a/_includes/p-menu.html
+++ b/_includes/p-menu.html
@@ -1,7 +1,7 @@
 			<nav class="p-menu">
 				<ul class="p-menu__list">
 					<li class="p-menu__item">
-						<a href="https://docs.openzeppelin.com" target="_blank">Docs</a>
+						<a href="{{ page.docs_url | default: "https://docs.openzeppelin.com" }}" target="_blank">Docs</a>
 					</li>
 					<li class="p-menu__item">
 						<a href="{{ page.github_url | default: "https://github.com/OpenZeppelin" }}" target="_blank">Github</a>

--- a/contracts.md
+++ b/contracts.md
@@ -1,5 +1,6 @@
 ---
 layout: contracts
 title: Contracts
+docs_url: https://docs.openzeppelin.com/contracts
 github_url: https://github.com/OpenZeppelin/openzeppelin-contracts
 ---

--- a/sdk.md
+++ b/sdk.md
@@ -1,5 +1,6 @@
 ---
 layout: sdk
 title: SDK
+docs_url: https://docs.openzeppelin.com/sdk
 github_url: https://github.com/OpenZeppelin/openzeppelin-sdk
 ---

--- a/starter-kits.md
+++ b/starter-kits.md
@@ -1,5 +1,6 @@
 ---
 layout: starter-kits
 title: Starter Kits
+docs_url: https://docs.openzeppelin.com/starter-kits
 github_url: https://github.com/OpenZeppelin/starter-kit
 ---


### PR DESCRIPTION
I made the docs link in each project's menu target the specific docs for that project instead of the docs home.