### PR TITLE
Tweak team images

### DIFF
--- a/_includes/team.html
+++ b/_includes/team.html
@@ -11,13 +11,11 @@
 
   .team-img {
     margin-bottom: 2.5rem;
-    border-radius: 6rem;
-    background-color: grey;
+    border-radius: 60px;
     height: 120px;
     width: 120px;
     margin: auto;
     margin-bottom: 1.5rem;
-    box-shadow: -2px 4px 10px 0 #f5f5f5, 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2);
   }
 
   .team-box p {
@@ -101,7 +99,7 @@
 <div class="">
   <div class="team-container">
     <div class="team-box">
-      <img src="../images/team/demi.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/demi.jpg" class="responsive-img team-img">
       <p class="title">Demian<span class="hide-on-small-only last-name"> Brener</span></p>
       <p class="small job-title">CEO</p>
       <p class="small hide-on-small-only">
@@ -110,7 +108,7 @@
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/fran.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/fran.jpg" class="responsive-img team-img">
       <p class="title">Francisco<span class="hide-on-small-only last-name"> Giordano</span></p>
       <p class="small job-title">Core dev</p>
       <p class="small hide-on-small-only">
@@ -119,7 +117,7 @@
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/albert.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/albert.jpg" class="responsive-img team-img">
       <p class="title">Albert<span class="hide-on-small-only last-name"> Gozzi</span></p>
       <p class="small job-title">COO</p>
       <p class="small hide-on-small-only">
@@ -128,7 +126,7 @@
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/palla.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/palla.jpg" class="responsive-img team-img">
       <p class="title">Santiago<span class="hide-on-small-only last-name"> Palladino</span></p>
       <p class="small job-title">Core dev</p>
       <p class="small hide-on-small-only">
@@ -137,7 +135,7 @@
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/marto.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/marto.jpg" class="responsive-img team-img">
       <p class="title">Martin<span class="hide-on-small-only last-name"> Triay</span></p>
       <p class="small job-title">Communications</p>
       <p class="small hide-on-small-only">
@@ -146,7 +144,7 @@
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/alejo.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/alejo.jpg" class="responsive-img team-img">
       <p class="title">Alejo<span class="hide-on-small-only last-name"> Salles</span></p>
       <p class="small job-title">Core dev</p>
       <p class="small hide-on-small-only">
@@ -155,7 +153,7 @@
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/leo.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/leo.jpg" class="responsive-img team-img">
       <p class="title">Leonardo<span class="hide-on-small-only last-name"> Arias</span></p>
       <p class="small job-title">Core dev</p>
       <p class="small hide-on-small-only">
@@ -164,7 +162,7 @@
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/nico.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/nico.jpg" class="responsive-img team-img">
       <p class="title">Nicolas<span class="hide-on-small-only last-name"> Venturo</span></p>
       <p class="small job-title">Core dev</p>
       <p class="small hide-on-small-only">
@@ -173,7 +171,7 @@
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/orne.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/orne.jpg" class="responsive-img team-img">
       <p class="title">Ornella<span class="hide-on-small-only last-name"> Cordoba</span></p>
       <p class="small job-title">Communications</p>
       <p class="small hide-on-small-only">
@@ -181,7 +179,7 @@
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/agos.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/agos.jpg" class="responsive-img team-img">
       <p class="title">Agostina<span class="hide-on-small-only last-name"> Blanco</span></p>
       <p class="small job-title">Design</p>
       <p class="small hide-on-small-only">
@@ -190,7 +188,7 @@
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/jota.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/jota.jpg" class="responsive-img team-img">
       <p class="title">Juan Bautista<span class="hide-on-small-only last-name"> Carpanelli</span></p>
       <p class="small job-title">Core dev</p>
       <p class="small hide-on-small-only">
@@ -199,14 +197,14 @@
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/sofi.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/sofi.jpg" class="responsive-img team-img">
       <p class="title">Sofia<span class="hide-on-small-only last-name"> Vissani</span></p>
       <p class="small job-title">Finance</p>
       <p class="small hide-on-small-only">
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/tincho.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/tincho.jpg" class="responsive-img team-img">
       <p class="title">Martin<span class="hide-on-small-only last-name"> Abbatemarco</span></p>
       <p class="small job-title">Core dev</p>
       <p class="small hide-on-small-only">
@@ -214,7 +212,7 @@
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/caro.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/caro.jpg" class="responsive-img team-img">
       <p class="title">Carolina<span class="hide-on-small-only last-name"> Jacob</span></p>
       <p class="small job-title">HR</p>
       <p class="small hide-on-small-only">
@@ -223,7 +221,7 @@
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/juan.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/juan.jpg" class="responsive-img team-img">
       <p class="title">John<span class="hide-on-small-only last-name"> Neufeld</span></p>
       <p class="small job-title">Legal</p>
       <p class="small hide-on-small-only">
@@ -231,7 +229,7 @@
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/dennison.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/dennison.jpg" class="responsive-img team-img">
       <p class="title">Dennison<span class="hide-on-small-only last-name"> Bertram</span></p>
       <p class="small job-title">Development Advocate</p>
       <p class="small hide-on-small-only">
@@ -240,7 +238,7 @@
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/igor.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/igor.jpg" class="responsive-img team-img">
       <p class="title">Igor<span class="hide-on-small-only last-name"> Yalovoy</span></p>
       <p class="small job-title">Core dev</p>
       <p class="small hide-on-small-only">
@@ -249,7 +247,7 @@
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/rick.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/rick.jpg" class="responsive-img team-img">
       <p class="title">Rick<span class="hide-on-small-only last-name"> Chen</span></p>
       <p class="small job-title">Core dev</p>
       <p class="small hide-on-small-only">
@@ -258,7 +256,7 @@
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/bachi.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/bachi.jpg" class="responsive-img team-img">
       <p class="title">Andres<span class="hide-on-small-only last-name"> Bachfischer</span></p>
       <p class="small job-title">Core dev</p>
       <p class="small hide-on-small-only">
@@ -266,7 +264,7 @@
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/nikesh.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/nikesh.jpg" class="responsive-img team-img">
       <p class="title">Nikesh<span class="hide-on-small-only last-name"> Nazareth</span></p>
       <p class="small job-title">Core dev</p>
       <p class="small hide-on-small-only">
@@ -275,7 +273,7 @@
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/austin.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/austin.jpg" class="responsive-img team-img">
       <p class="title">Austin<span class="hide-on-small-only last-name"> Williams</span></p>
       <p class="small job-title">Core dev</p>
       <p class="small hide-on-small-only">
@@ -283,7 +281,7 @@
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/nacho.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/nacho.jpg" class="responsive-img team-img">
       <p class="title">Ignacio<span class="hide-on-small-only last-name"> Bonilla</span></p>
       <p class="small job-title">Core dev</p>
       <p class="small hide-on-small-only">
@@ -291,7 +289,7 @@
       </p>
     </div>
     <div class="team-box">
-      <img src="../images/team/eric.jpg" class="circle responsive-img team-img">
+      <img src="../images/team/eric.jpg" class="responsive-img team-img">
       <p class="title">Eric<span class="hide-on-small-only last-name"> Decourcy</span></p>
       <p class="small job-title">Core dev</p>
       <p class="small hide-on-small-only">


### PR DESCRIPTION
I noticed the team images had a bit of a glitchy halo that was caused by a background color. I also removed the box-shadow because I thought it looked better but we can add it back.

I changed the `border-radius` from `rem` to `px` so that it's specified in the same unit as the `height` and `width`. It seems more reliable to me.