### PR TITLE
Prevent default event handler on click of dropdown menu titles

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -7,6 +7,9 @@
         var $el = $(this).find('.sub-nav');
         $el.toggleClass('open');
       });
+      $items.click(function (evt) {
+        evt.preventDefault();
+      });
     })();
   }
 


### PR DESCRIPTION
Clicking on the dropdown menu titles (e.g. "Products") was causing the site to scroll to the top.

I don't think those titles should be links at all, but I don't know if it's safe to change that.