### PR TITLE
Make Contracts and SDK Call to Action link to the docsite

### DIFF
--- a/_layouts/contracts.html
+++ b/_layouts/contracts.html
@@ -33,7 +33,7 @@ layout: default
 			<h1 class="heading">Build Secure Smart Contracts in Solidity</h1>
 			<p class="description">OpenZeppelin Contracts helps you minimize risk by using battle-tested libraries of smart
 				contracts for Ethereum and other blockchains. It includes the most used implementations of ERC standards.</p>
-			<a href="https://github.com/openzeppelin/openzeppelin-contracts" class="btn cta">Get Started</a>
+			<a href="https://docs.openzeppelin.com/contracts" class="btn cta">Get Started</a>
 		</div>
 		<div class="container term-container p-animated">
 			<section class="terminal-section" id="terminal-section">

--- a/_layouts/sdk.html
+++ b/_layouts/sdk.html
@@ -62,7 +62,7 @@ layout: default
 				OpenZeppelin SDK makes smart contract development easy. Save hours of development time by compiling, upgrading,
 				deploying, and interacting with smart contracts with our CLI.
 			</p>
-			<a href="https://github.com/openzeppelin/openzeppelin-sdk" class="btn cta">Get Started</a>
+			<a href="https://docs.openzeppelin.com/cli" class="btn cta">Get Started</a>
 		</div>
 		<div class="container term-container p-animated">
 			<section class="terminal-section" id="terminal-section">


### PR DESCRIPTION
We want our users to head to the documentation website, not the GitHub repository.