### PR TITLE
Create apply.html

### DIFF
--- a/_layouts/apply.html
+++ b/_layouts/apply.html
@@ -26,7 +26,7 @@ layout: default
     <div class="wrapper">
       <h1 class="heading fIu">Apply for OpenZeppelin Defender</h1>
       <p class="description fIu">
-        Use the form below to apply for OpenZeppelin Defender mainnet use. We are accepting only select teams at this time to join the early user group. 
+        Complete the form below to apply for OpenZeppelin Defender mainnet use. We are accepting only select teams at this time to join the early user group. 
       </p>
     </div>
   </div>

--- a/_layouts/apply.html
+++ b/_layouts/apply.html
@@ -1,0 +1,54 @@
+---
+layout: default
+---
+
+<style>
+.hero .wrapper { margin-bottom: 0px; }
+.page-audit-request .section--gray .container { padding: 5rem 3rem; }
+.page-audit-request .hero .description { max-width: 800px; }
+.page-audit-request .hero h1.heading { max-width: 80%; }
+
+@media (min-width: 980px) {
+  .hero .wrapper { margin-bottom: 0; }
+  .page-audit-request .section-request-form .description { white-space: nowrap; }
+  .page-audit-request .hero h1.heading {
+    font-size: 2.2rem;
+    max-width: 90%;
+  }
+}
+
+</style>
+
+<main class="page page-audit-request">
+
+<section class="section section--gray hero">
+  <div class="container">
+    <div class="wrapper">
+      <h1 class="heading fIu">Apply for OpenZeppelin Defender</h1>
+      <p class="description fIu">
+        Use the form below to apply for OpenZeppelin Defender mainnet use. We are accepting only select teams at this time to join the early user group. 
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="section request-form">
+  <div class="container">
+    <div class="wrapper wrapper--centered center">
+        <!--[if lte IE 8]>
+        <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2-legacy.js"></script>
+        <![endif]-->
+        <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2.js"></script>
+        <script>
+        hbspt.forms.create({
+	      portalId: "7795250",
+	      formId: "c2b18c4e-df28-47e7-ac3f-23bf8f5517d4"
+        });
+        </script>
+    </div>
+  </div>
+</section>
+
+</main>
+
+<script src="/js/fixedMenu.js"></script>

--- a/apply.md
+++ b/apply.md
@@ -1,5 +1,5 @@
 ---
 layout: apply
 title: Apply for OpenZeppelin Defender
-excerpt: 'Use the form below to apply for OpenZeppelin Defender mainnet use. We are accepting only select teams at this time to join the early user group. '
+excerpt: 'Complete this form to apply for OpenZeppelin Defender mainnet use. We are accepting only select teams at this time to join the early user group. '
 ---

--- a/apply.md
+++ b/apply.md
@@ -1,0 +1,5 @@
+---
+layout: apply
+title: Apply for OpenZeppelin Defender
+excerpt: 'Use the form below to apply for OpenZeppelin Defender mainnet use. We are accepting only select teams at this time to join the early user group. '
+---


### PR DESCRIPTION
The /apply page contains the application form for teams to apply for mainnet use. This page can be linked to directly from the /defender page for teams that want to inquire about mainnet use without entering into the app.  