### PR TITLE
Update Contracts example to OpenZeppelin Contracts 4

### DIFF
--- a/js/console.js
+++ b/js/console.js
@@ -80,7 +80,7 @@ function typeVim() {
         [
           '<span style="color: #228B22;">// contracts/ExampleToken.sol</span>',
           '<span style="color: #228B22;">// SPDX-License-Identifier: MIT</span>',
-          '<span style="color: #D26696;">pragma</span> solidity <span style="color: #D26696;">^^</span><span style="color: #AF7DFF;">0.8.0</span>;',
+          '<span style="color: #D26696;">pragma</span> solidity <span style="color: #D26696;">^^</span><span style="color: #AF7DFF;">0.7.0</span>;',
           '<div style="height:8px"></div><span style="color: #D26696;">import</span> <span style="color:#F6D8A0;">"@openzeppelin/contracts/token/ERC20/<br><span class="mobile-br">&nbsp;</span>ERC20.sol"</span>;',
           '<div style="height:8px"></div><span style="color: #D26696;">contract</span> <span style="color:#788DD1">ExampleToken</span> is <span style="color:#788DD1">ERC20</span> {',
           '<div style="height:8px"></div><span class="terminal-padding"><span style="color: #788DD1;">constructor</span> ()',

--- a/js/console.js
+++ b/js/console.js
@@ -43,7 +43,7 @@ function fixedText1and2() {
   $('.terminal .typed-cursor').css('color', 'black');
   setTimeout(function() {
     document.getElementById('fixed-text').innerHTML =
-      '</br> + @openzeppelin/contracts@2.4.0</br>';
+      '</br> + @openzeppelin/contracts</br>';
   }, 200);
   setTimeout(function() {
     $('#typed2').typed({
@@ -78,16 +78,17 @@ function typeVim() {
     $('#typed-vim').typed({
       strings: [
         [
-          '<span style="color: #D26696;">pragma</span> solidity <span style="color: #D26696;">^^</span><span style="color: #AF7DFF;">0.5.0</span>;',
+          '<span style="color: #228B22;">// contracts/ExampleToken.sol</span>',
+          '<span style="color: #228B22;">// SPDX-License-Identifier: MIT</span>',
+          '<span style="color: #D26696;">pragma</span> solidity <span style="color: #D26696;">^^</span><span style="color: #AF7DFF;">0.8.0</span>;',
           '<div style="height:8px"></div><span style="color: #D26696;">import</span> <span style="color:#F6D8A0;">"@openzeppelin/contracts/token/ERC20/<br><span class="mobile-br">&nbsp;</span>ERC20.sol"</span>;',
-          '<div style="height:8px"></div><span style="color: #D26696;">import</span> <span style="color:#F6D8A0;">"@openzeppelin/contracts/token/ERC20/<br><span class="mobile-br">&nbsp;</span>ERC20Detailed.sol"</span>;',
-          '<div style="height:8px"></div><span style="color: #D26696;">contract</span> <span style="color:#788DD1">ExampleToken</span> is <span style="color:#788DD1">ERC20, ERC20Detailed</span> {',
-          '<div style="height:8px"></div><span class="terminal-padding"><span style="color: #788DD1;">constructor</span> () <span style="color: #788DD1;">public</span>',
-          '<span class="terminal-padding2">ERC20Detailed("ExampleToken", "EGT", 18)',
+          '<div style="height:8px"></div><span style="color: #D26696;">contract</span> <span style="color:#788DD1">ExampleToken</span> is <span style="color:#788DD1">ERC20</span> {',
+          '<div style="height:8px"></div><span class="terminal-padding"><span style="color: #788DD1;">constructor</span> ()',
+          '<span class="terminal-padding2">ERC20("ExampleToken", "EGT")',
           '<span class="terminal-padding">{</span>',
           '<span class="terminal-padding2">_mint(</span>',
           '<span class="terminal-padding3">msg.sender,</span>',
-          '<span class="terminal-padding3">10000 * (10 ** uint256(decimals()))</span>',
+          '<span class="terminal-padding3">10000 * (10**uint256(decimals()))</span>',
           '<span class="terminal-padding2">);</span>',
           '<span class="terminal-padding">}^500',
           '}',
@@ -110,7 +111,7 @@ function typeThree() {
   setTimeout(function() {
     $('#typed3').typed({
       strings: [
-        '<br>[~] $ truffle console^500</br>> const myToken = await ExampleToken.new()^500</br>> (await myToken.totalSupply()).toString()',
+        '<br>[~] $ npx truffle compile^500</br>[~] $ npx truffle develop^500</br>> const myToken = await ExampleToken.new()^500</br>> (await myToken.totalSupply()).toString()',
       ],
       typespeed: 800,
       backdelay: 0,


### PR DESCRIPTION
Update Contracts ERC20 token example to OpenZeppelin Contracts 4.0
Doesn't include `@next` tag.